### PR TITLE
Made brancho executable from anywhere, fixed bug when sub-task is par…

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,3 +1,3 @@
 <?php
 
-define('APPLICATION_ROOT_DIR', __DIR__);
+define('ROOT_DIR', __DIR__);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,5 @@
 parameters:
     checkMissingIterableValueType: false
+
+    bootstrapFiles:
+        - phpstan-bootstrap.php

--- a/src/Brancho/Command/BranchBuilderCommand.php
+++ b/src/Brancho/Command/BranchBuilderCommand.php
@@ -34,7 +34,7 @@ class BranchBuilderCommand extends AbstractCommand
                 static::CONFIG_SHORTCUT,
                 InputOption::VALUE_REQUIRED,
                 'Path to a configuration file (default: .brancho)',
-                getcwd() . '/.brancho'
+                ROOT_DIR . '/.brancho'
             );
     }
 
@@ -96,7 +96,7 @@ class BranchBuilderCommand extends AbstractCommand
      */
     protected function createBranch(string $branchName): void
     {
-        $process = new Process(['git', 'checkout', '-b', $branchName]);
+        $process = new Process(['git', 'checkout', '-b', $branchName], (string)getcwd());
         $process->run();
     }
 }

--- a/src/Brancho/Resolver/JiraResolver.php
+++ b/src/Brancho/Resolver/JiraResolver.php
@@ -74,9 +74,10 @@ class JiraResolver extends AbstractResolver implements ConfigurableResolverInter
 
         $epicOrStoryJiraIssue = $this->getParentJiraIssue($jiraIssue, $config);
         $epicOrStoryIssue = $filter->filter($epicOrStoryJiraIssue['key']);
+        $epicOrStoryIssueType = $filter->filter($epicOrStoryJiraIssue['fields']['issuetype']['name']);
         $issue = sprintf('%s/%s', $epicOrStoryIssue, $issue);
 
-        if ($issueType === 'sub-task') {
+        if ($issueType === 'sub-task' && $epicOrStoryIssueType !== 'epic') {
             $epicJiraIssue = $this->getParentJiraIssue($epicOrStoryJiraIssue, $config);
             $epicIssue = $filter->filter($epicJiraIssue['key']);
 

--- a/tests/_support/Helper/CommandHelper.php
+++ b/tests/_support/Helper/CommandHelper.php
@@ -9,6 +9,13 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class CommandHelper extends Module
 {
+    /**
+     * @return void
+     */
+    public function _initialize(): void
+    {
+        defined('ROOT_DIR') || define('ROOT_DIR', getcwd());
+    }
 
     /**
      * @param \Symfony\Component\Console\Command\Command $command


### PR DESCRIPTION
It was not possible to run the brancho command from with e.g. spryker/spryker to create a branch there, this is now possible.
Fixed a bug when a sub-task's parent is an epic instead of an expected task. 